### PR TITLE
Adds note about installing SWIG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,7 @@ Building
 
    .. code:: bash
 
-             $ sudo apt-get install swig
-             $ sudo apt install gnuradio-dev
+             $ sudo apt install gnuradio-dev swig
 
 #. Build and install srsLTE. There is a naming collision between srsLTE
    and a requirement of GNU Radio, which we must fix before building:

--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,11 @@ Screenshots
 Building
 --------
 
-#. Install GNU Radio (example assumes Ubuntu 16.04, adjust as needed)
+#. Install SWIG and GNU Radio (example assumes Ubuntu 16.04, adjust as needed)
 
    .. code:: bash
 
+             $ sudo apt-get install swig
              $ sudo apt install gnuradio-dev
 
 #. Build and install srsLTE. There is a naming collision between srsLTE


### PR DESCRIPTION
Tested an install on a fresh ubuntu 16.04 install, and lack of SWIG caused my builds to fail.